### PR TITLE
[chore] 검색조건 title 빠져있던거 추가

### DIFF
--- a/src/main/java/project/tripplan/domain/plan/controller/PlanController.java
+++ b/src/main/java/project/tripplan/domain/plan/controller/PlanController.java
@@ -1,7 +1,6 @@
 package project.tripplan.domain.plan.controller;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -67,6 +66,7 @@ public class PlanController {
 	public BaseResponse<PlanNoOffsetRes> getPlans(@ModelAttribute PlanConditionReq queryParam) {
 
 		PlanNoOffsetReq req = new PlanNoOffsetReq();
+		req.setTitle(queryParam.getTitle());
 		req.setSize(queryParam.getSize() != null ? queryParam.getSize() : 10);
 		req.setSortBy(queryParam.getSortBy());
 		req.setDirection(queryParam.getDirection());

--- a/src/main/java/project/tripplan/domain/plan/dto/PlanConditionReq.java
+++ b/src/main/java/project/tripplan/domain/plan/dto/PlanConditionReq.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class PlanConditionReq {
+	private String title;
 	private Integer size;
 	private String sortBy;
 	private String direction;

--- a/src/main/java/project/tripplan/domain/plan/dto/PlanContentAndTotalCountRes.java
+++ b/src/main/java/project/tripplan/domain/plan/dto/PlanContentAndTotalCountRes.java
@@ -1,0 +1,17 @@
+package project.tripplan.domain.plan.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import project.tripplan.domain.plan.entity.Plan;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PlanContentAndTotalCountRes {
+
+	private List<Plan> content;
+	private long totalCount;
+}

--- a/src/main/java/project/tripplan/domain/plan/dto/PlanNoOffsetReq.java
+++ b/src/main/java/project/tripplan/domain/plan/dto/PlanNoOffsetReq.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 @Setter
 public class PlanNoOffsetReq {
 
+	private String title;
 	private int size;                  // 페이지 크기
 	private String sortBy;             // 정렬 기준 (예: "viewCount", "id")
 	private String direction;          // 정렬 방향 (예: "ASC", "DESC")

--- a/src/main/java/project/tripplan/domain/plan/dto/PlanNoOffsetRes.java
+++ b/src/main/java/project/tripplan/domain/plan/dto/PlanNoOffsetRes.java
@@ -10,4 +10,6 @@ public class PlanNoOffsetRes {
 	private Boolean hasNext;           // 다음 페이지 존재 여부
 	private String nextValue;          // 다음 페이지 커서 값
 	private Long nextId;               // 다음 페이지 커서 pk
+	private long totalCount;           // 전체 카운트
+
 }

--- a/src/main/java/project/tripplan/domain/plan/repository/PlanRepositoryCustom.java
+++ b/src/main/java/project/tripplan/domain/plan/repository/PlanRepositoryCustom.java
@@ -6,15 +6,15 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import project.tripplan.domain.plan.dto.PlanContentAndTotalCountRes;
 import project.tripplan.domain.plan.dto.PlanNoOffsetReq;
 import project.tripplan.domain.plan.entity.Plan;
 import project.tripplan.domain.user.dto.UserPlanRes;
-import project.tripplan.domain.plan.entity.PlanPlaceCategory;
 
 public interface PlanRepositoryCustom {
 	Optional<Plan> findByPlanIdWithUser(Long planId);
 
-	List<Plan> searchPlanNoOffset(PlanNoOffsetReq req);
+	PlanContentAndTotalCountRes searchPlanNoOffset(PlanNoOffsetReq req);
 
 	List<Plan> findMostViewedPlans(int limit);
 

--- a/src/main/java/project/tripplan/domain/plan/repository/PlanRepositoryCustomImpl.java
+++ b/src/main/java/project/tripplan/domain/plan/repository/PlanRepositoryCustomImpl.java
@@ -1,6 +1,5 @@
 package project.tripplan.domain.plan.repository;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,13 +19,14 @@ import lombok.extern.slf4j.Slf4j;
 import project.tripplan.domain.category.placeCategory.entity.QPlaceCategory;
 import project.tripplan.domain.category.transportationCategory.entitiy.QTransportationCategory;
 import project.tripplan.domain.category.transportationCategory.enums.TransportationName;
+import project.tripplan.domain.plan.dto.PlanContentAndTotalCountRes;
 import project.tripplan.domain.plan.dto.PlanNoOffsetReq;
 import project.tripplan.domain.plan.entity.Plan;
 import project.tripplan.domain.plan.entity.QPlan;
 import project.tripplan.domain.plan.entity.QPlanPlaceCategory;
 import project.tripplan.domain.plan.entity.QPlanTransportationCategory;
-import project.tripplan.domain.user.dto.UserPlanRes;
 import project.tripplan.domain.plan.enums.PlanStatus;
+import project.tripplan.domain.user.dto.UserPlanRes;
 import project.tripplan.domain.user.entity.QUser;
 
 @Slf4j
@@ -53,7 +53,13 @@ public class PlanRepositoryCustomImpl implements PlanRepositoryCustom {
 	}
 
 	@Override
-	public List<Plan> searchPlanNoOffset(PlanNoOffsetReq req) {
+	public PlanContentAndTotalCountRes searchPlanNoOffset(PlanNoOffsetReq req) {
+		List<Plan> content = getContent(req);
+		long totalCount = getTotalCount(req);
+		return new PlanContentAndTotalCountRes(content, totalCount);
+	}
+
+	private List<Plan> getContent(PlanNoOffsetReq req) {
 		// (A) limit
 		int limit = req.getSize() + 1;
 
@@ -82,6 +88,11 @@ public class PlanRepositoryCustomImpl implements PlanRepositoryCustom {
 
 	private BooleanBuilder buildSearchCondition(PlanNoOffsetReq req) {
 		BooleanBuilder builder = new BooleanBuilder();
+
+		// title검색 조건
+		if (req.getTitle() != null && !req.getTitle().isBlank()) {
+			builder.and(plan.title.likeIgnoreCase("%" + req.getTitle() + "%"));
+		}
 
 		// 1) 카테고리 ID in (OR 조건)
 		if (req.getCategoryIds() != null && !req.getCategoryIds().isEmpty()) {
@@ -176,6 +187,22 @@ public class PlanRepositoryCustomImpl implements PlanRepositoryCustom {
 				}
 				break;
 		}
+	}
+
+	private long getTotalCount(PlanNoOffsetReq req) {
+		BooleanBuilder builder = buildSearchCondition(req);
+
+		Long countResult = qf
+			.select(plan.countDistinct())
+			.from(plan)
+			.leftJoin(plan.planPlaceCategories, planPlaceCategory)
+			.leftJoin(planPlaceCategory.placeCategory, placeCategory)
+			.leftJoin(plan.planTransportationCategories, planTransport)
+			.leftJoin(planTransport.transportationCategory, transportationCategory)
+			.where(builder)
+			.fetchOne();
+
+		return (countResult != null) ? countResult : 0;
 	}
 
 	@Override

--- a/src/main/java/project/tripplan/domain/plan/service/PlanService.java
+++ b/src/main/java/project/tripplan/domain/plan/service/PlanService.java
@@ -33,6 +33,7 @@ import project.tripplan.domain.plan.dto.DetailReq;
 import project.tripplan.domain.plan.dto.HomeRes;
 import project.tripplan.domain.plan.dto.PlaceCategoryNamesReq;
 import project.tripplan.domain.plan.dto.PlanCommentsRes;
+import project.tripplan.domain.plan.dto.PlanContentAndTotalCountRes;
 import project.tripplan.domain.plan.dto.PlanDetailRes;
 import project.tripplan.domain.plan.dto.PlanNoOffsetReq;
 import project.tripplan.domain.plan.dto.PlanNoOffsetRes;
@@ -194,7 +195,7 @@ public class PlanService {
 		Plan findPlan = planRepositoryCustom.findByPlanIdWithUser(planId)
 			.orElseThrow(() -> new CustomException(BaseResponseCode.PLAN_NOT_EXIST));
 
-		if(findPlan.getUser().getId() != user.getId()) {
+		if (findPlan.getUser().getId() != user.getId()) {
 			throw new CustomException(BaseResponseCode.UNAUTHORIZED_POST_UPDATE_STATUS);
 		}
 
@@ -268,20 +269,19 @@ public class PlanService {
 		// 1) categoryNames가 있는 경우, 자식까지 포함한 categoryIds 구하기 (OR 조건)
 		if (req.getCategoryNames() != null && !req.getCategoryNames().isEmpty()) {
 			Set<Long> allIds = placeCategoryService.findAllDescendantCategoryIds(req.getCategoryNames());
-			// allIds는 "카테고리들의 합집합" => OR 조건에 사용
 			req.setCategoryIds(allIds);
 		}
 
 		// 2) DB 조회 (size+1 개)
-		List<Plan> rawList = planRepositoryCustom.searchPlanNoOffset(req);
+		PlanContentAndTotalCountRes rawList = planRepositoryCustom.searchPlanNoOffset(req);
 
 		// 3) hasNext (size 이상이면 다음 페이지 존재)
-		boolean hasNext = rawList.size() > req.getSize();
+		boolean hasNext = rawList.getContent().size() > req.getSize();
 
 		// 4) 실제 반환 목록 (size까지만)
 		List<Plan> content = hasNext
-			? rawList.subList(0, req.getSize())
-			: rawList;
+			? rawList.getContent().subList(0, req.getSize())
+			: rawList.getContent();
 
 		// 5) nextValue, nextId 설정 (전통적 switch 문)
 		String nextValue = null;
@@ -316,6 +316,7 @@ public class PlanService {
 		response.setHasNext(hasNext);
 		response.setNextValue(nextValue);
 		response.setNextId(nextId);
+		response.setTotalCount(rawList.getTotalCount());
 
 		return response;
 	}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #28 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 📝작업 내용

> plan 검색시 title 검색조건은 빠져있던거 추가함.
where절 like문장 추가.

ex) 
http://localhost:8080/plans/search?title=ㅁㅁ&size=10&sortBy=viewCount&transportCategoryName=CAR&people=5&categoryNames=전남-0&categoryNames=안양/광명/부천-1&categoryNames=평택/시흥/안산-1

~~~
{
    "status": true,
    "code": 1406,
    "message": "계획글 조건 검색 불러오기에 성공했습니다.",
    "data": {
        "plans": [
            {
                "planId": 6,
                "title": "ㅁㅁ",
                "image": "6f9d95a4-6c11-45e9-83de-2b249f269d9f.jpeg",
                "category": [
                    "제주시",
                    "전주/익산/군산"
                ],
                "startDate": "2025-07-01",
                "endDate": "2025-07-07",
                "people": 5,
                "transportCategoryName": "CAR",
                "totalCost": 180000
            }
        ],
        "hasNext": false,
        "nextValue": "0",
        "nextId": 6,
        "totalCount": 1
    }
}
~~~


